### PR TITLE
Adds HelperError rescue class

### DIFF
--- a/oculusweb.rb
+++ b/oculusweb.rb
@@ -15,6 +15,9 @@ require File.join(File.dirname(__FILE__), 'helpers/fingerprint')
 
 $sockets = []
 
+class HelperError < StandardError
+end
+
 class Oculusweb < Sinatra::Base
 
    # Comment out the following 3 lines if you want more verbose logging


### PR DESCRIPTION
The missing HelperError rescue class obfuscates the real problem or error should one arise in the web app.

For example, with the HelperError rescue class in place I can see this error:

<pre>
Redis::CannotConnectError at /
Error connecting to Redis on 11.22.33.44:6379 (ECONNREFUSED)
</pre>


But without the class I only see:

<pre>
NameError at /
uninitialized constant Oculusweb::HelperError
</pre>
